### PR TITLE
use foldLeft instead of /:

### DIFF
--- a/core/src/main/scala/twotails/mutualrec.scala
+++ b/core/src/main/scala/twotails/mutualrec.scala
@@ -143,7 +143,7 @@ final class MutualRecComponent(val global: Global, limitSize: () => Boolean)
         val DefDef(_, _, _, vp :: vps, _, _) = tree
         val newVp = localTyper.typed(Literal(Constant(indx))) :: vp.map(p => gen.paramToArg(p.symbol))
         val refTree = gen.mkAttributedRef(tree.symbol.owner.thisType, methSym)
-        val forwarderTree = (Apply(refTree, newVp) /: vps){
+        val forwarderTree = vps.foldLeft(Apply(refTree, newVp)){
           (fn, params) => Apply(fn, params map (p => gen.paramToArg(p.symbol)))
         }
         val forwarded = deriveDefDef(tree)(_ => localTyper.typedPos(tree.symbol.pos)(forwarderTree))


### PR DESCRIPTION
deprecated since Scala 2.13
https://github.com/scala/scala/blob/v2.13.0-M4/src/library/scala/collection/IterableOnce.scala#L465