### PR TITLE
Fix 'no arguments allowed for nullary method'-error

### DIFF
--- a/core/src/main/scala/twotails/mutualrec.scala
+++ b/core/src/main/scala/twotails/mutualrec.scala
@@ -283,7 +283,7 @@ final class MutualRecComponent(val global: Global, limitSize: () => Boolean)
     private val band = currentRun.runDefinitions.Boolean_and
 
     def walk(tree: Tree): List[Symbol] ={
-      calls clear ()
+      calls.clear()
       tree match { 
         case x:DefDef => traverse(x.rhs)
         case _ => ()


### PR DESCRIPTION
This was uncovered in the community build for scala 2.13.0-RC1, see scala/bug#11453